### PR TITLE
Change Last announces to Latest announcements

### DIFF
--- a/core/lang/english.rb
+++ b/core/lang/english.rb
@@ -19,7 +19,7 @@
     define("header_menu_cuenta", "Account");
     define("header_menu_salir", "Logout");
                  
-    define("social", "Last announces");
+    define("social", "Latest announcements");
  
     define("foro_main", "Forums");
     define("foro_main_desc", "Socialize with your friends");


### PR DESCRIPTION
The reason why I changed Last announces to Latest announcements is because Latest announcements sounds better than last annonces and also ocn does it.